### PR TITLE
Created spot.handlebars view

### DIFF
--- a/controllers/spot-router.js
+++ b/controllers/spot-router.js
@@ -1,19 +1,15 @@
-const router = require("express").Router();
-const { User, Spot, Tag, SpotTag } = require("../models");
+const router = require('express').Router();
+const { User, Spot, Tag, SpotTag } = require('../models');
 
 // use withAuth middleware to redirect from protected routes.
-const withAuth = require("../util/withAuth");
+const withAuth = require('../util/withAuth');
 
-router.get("/", withAuth, async (req, res) => {
-  res.render("spot");
-});
-
-router.get("/:id", async (req, res) => {
+router.get('/:id', async (req, res) => {
   try {
     let user;
     if (req.session.isLoggedIn) {
       user = await User.findByPk(req.session.userId, {
-        exclude: ["password"],
+        exclude: ['password'],
         raw: true,
       });
     }
@@ -31,7 +27,7 @@ router.get("/:id", async (req, res) => {
             model: SpotTag,
             attributes: [],
           },
-          as: "tags",
+          as: 'tags',
         },
       ],
     });
@@ -40,17 +36,17 @@ router.get("/:id", async (req, res) => {
     const spot = spotData.get({ plain: true });
 
     const data = {
-      title: "MySpot",
+      title: 'MySpot',
       isLoggedIn: req.session.isLoggedIn,
       user,
       spot,
     };
     console.log(data);
 
-    res.render("spot", data);
+    res.render('spot', data);
   } catch (error) {
     console.error(error);
-    res.status(500).send("⛔ Uh oh! An unexpected error occurred.");
+    res.status(500).send('⛔ Uh oh! An unexpected error occurred.');
   }
 });
 

--- a/views/spot.handlebars
+++ b/views/spot.handlebars
@@ -1,0 +1,28 @@
+<div class="container-sm">
+  <div class="row justify-content-center">
+    <div class="col-sm-12 col-lg-6 my-2">
+      <div class="card">
+        <div class="h1 text-center">Spot Details</div>
+        <div class="card-header" id="staticmap" data-longitude={{spot.longitude}} data-latitude={{spot.latitude}}>
+        </div>
+        <div class="card-body">
+          <h2 class="card-title">{{spot.title}}</h2>
+          <h5 class="card-title">Spot pinned by: {{spot.user.username}}</h5>
+          <p class="card-text">{{spot.description}}</p>
+        </div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item">Longitude: {{spot.longitude}}</li>
+          <li class="list-group-item">Latitude: {{spot.latitude}}</li>
+          <li class="list-group-item">Tags: 
+            <ul class="card-text">
+              {{#each spot.tags as |tag|}}
+              <li>{{tag.tag_name}}</li>
+              {{/each}}
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="/js/map.js"></script>


### PR DESCRIPTION
Created a spot.handlebars view. This can be tested by starting the server and navigating to
`localhost:3001/spot/1`

Also removed /spot as a route since it was too ambiguous where the user wants to go without specifying the spot id. Currently there is no replacement, but if anyone has any ideas of what to do with a url like `localhost:3001/spot` then let me know.